### PR TITLE
copy only relevant files into Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM python:3.6-slim
 
+# Make the /app dir
+RUN mkdir /app
+
 # Set the working directory to /app
 WORKDIR /app
 
-# Copy the current directory contents into the container at /app
-COPY . /app
+# Copy required files to /app
+COPY fritzinfluxdb.py requirements.txt ./
 
 # Install any needed packages specified in requirements.txt
 RUN pip install --trusted-host pypi.python.org -r requirements.txt


### PR DESCRIPTION
Copy only files that are required in the Docker image to the Docker image (`requirements.txt`, `fritzinfluxdb.py`). That way, the Docker build cache is only invalidated if something changes in either of these files.